### PR TITLE
Add Go CI workflow

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,0 +1,34 @@
+# This workflow will build a golang project
+# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-go
+
+name: Go CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  golangci:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+
+    - name: Set up Go
+      uses: actions/setup-go@v5
+      with:
+        go-version: '1.22.x'
+
+    - name: Check for mod tidy
+      run: |
+        go mod tidy
+        git diff --exit-code go.mod go.sum || exit 1
+
+    - name: Check Code Style
+      run: |
+        if ! gofmt -s -l -w . | git diff --exit-code; then
+          exit 1
+        fi
+
+    - name: Build
+      run: go build -v ./...


### PR DESCRIPTION
This pull request adds a Go CI workflow that builds a golang project. It sets up Go version 1.22.x, checks for mod tidy, checks code style using gofmt, and builds the project using "go build -v ./...".