### PR TITLE
Add .gitignore for Go project

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,21 @@
+# If you prefer the allow list template instead of the deny list, see community template:
+# https://github.com/github/gitignore/blob/main/community/Golang/Go.AllowList.gitignore
+#
+# Binaries for programs and plugins
+*.exe
+*.exe~
+*.dll
+*.so
+*.dylib
+
+# Test binary, built with `go test -c`
+*.test
+
+# Output of the go coverage tool, specifically when used with LiteIDE
+*.out
+
+# Dependency directories (remove the comment below to include it)
+# vendor/
+
+# Go workspace file
+go.work


### PR DESCRIPTION
This pull request adds a .gitignore file for the Go project. The .gitignore file includes common files and directories that should be ignored by Git, such as binaries, test files, and dependency directories. This helps to keep the repository clean and prevents unnecessary files from being committed. Fixes #1