### PR TITLE
Add Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,3 +10,14 @@ updates:
    directory: "/"
    schedule:
      interval: daily
+
+  - package-ecosystem: "gomod" # See documentation for possible values
+    directory: "/" # Location of package manifests
+    schedule:
+      interval: "daily"
+
+  - package-ecosystem: 'github-actions'
+    # Workflow files stored in the default location of `.github/workflows`. (You don't need to specify `/.github/workflows` for `directory`. You can use `directory: "/"`.
+    directory: '/'
+    schedule:
+      interval: 'daily'


### PR DESCRIPTION
This pull request adds a daily schedule for Dependabot updates. It includes changes to the `.github/dependabot.yml` file to configure Dependabot to check for updates on a daily basis for package manifests in the `gomod` ecosystem and workflow files in the `github-actions` ecosystem. This will help ensure that our project's dependencies and workflows are kept up to date. Fixes #2