### PR TITLE
Add devcontainer-build.yml for Go build in DevContainer

### DIFF
--- a/.github/workflows/devcontainer-build.yml
+++ b/.github/workflows/devcontainer-build.yml
@@ -1,0 +1,20 @@
+name: Go Build in DevContainer
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  build-in-devcontainer:
+    name: Build in DevContainer
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+
+    - name: Build
+      uses: devcontainers/ci@v0.3
+      with:
+        runCmd: |
+          go build ./...


### PR DESCRIPTION
This pull request adds a new file, devcontainer-build.yml, which enables Go build in DevContainer. This file contains the necessary configuration for building Go projects in a DevContainer environment. This change addresses issue #17.