### PR TITLE
Update SSL mode in database connection string

### DIFF
--- a/pkg/db/detabase.go
+++ b/pkg/db/detabase.go
@@ -18,7 +18,7 @@ func ConnectDB() *sql.DB {
 	dbName := os.Getenv("DB_NAME")
 
 	// データベース接続文字列の作成
-	dsn := fmt.Sprintf("host=%s port=%s user=%s password=%s dbname=%s sslmode=disable", dbHost, dbPort, dbUser, dbPassword, dbName)
+	dsn := fmt.Sprintf("host=%s port=%s user=%s password=%s dbname=%s sslmode=enable", dbHost, dbPort, dbUser, dbPassword, dbName)
 
 	// データベースへの接続
 	db, err := sql.Open("postgres", dsn)


### PR DESCRIPTION
This pull request updates the SSL mode in the database connection string from "disable" to "enable". This change ensures that the connection to the database is secure.

Fixes #37